### PR TITLE
Ensure headers are sent for relative path requests

### DIFF
--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -9,7 +9,7 @@
             url="{{url}}"
             params="{{params}}"
             method="{{method}}"
-            headers="[[requestHeaders]]"
+            headers="{{computeHeaders(headers, authToken)}}"
             contentType="{{contentType}}"
             body="{{body}}"
             handleAs="{{handleAs}}"
@@ -92,12 +92,13 @@
                     value: '*:*:*'
                 },
 
-                authToken: String,
-                xsrfToken: String,
-                requestHeaders: {
-                    type: Object,
-                    computed: 'getRequestHeaders(authToken)'
+                authToken: {
+                    type: String,
+                    value: function() {
+                        return null;
+                    }
                 },
+                xsrfToken: String,
                 cachedTokens: {
                     type: Object,
                     readOnly: true,
@@ -130,21 +131,21 @@
             detached: function () {
                 window.removeEventListener('storage', this.sessionChangedHandler);
             },
-            getRequestHeaders: function(authToken) {
-                var headers = {},
+            computeHeaders: function(headers, authToken) {
+                var result = {},
                     header;
 
                 if (authToken) {
-                    headers.Authorization = 'Bearer ' + authToken;
+                    result.Authorization = 'Bearer ' + authToken;
                 }
 
-                if (this.headers instanceof Object) {
-                    for (header in this.headers) {
-                        headers[header] = this.headers[header].toString();
+                if (headers instanceof Object) {
+                    for (header in headers) {
+                        result[header] = headers[header].toString();
                     }
                 }
 
-                return headers;
+                return result;
             },
             generateRequest: function() {
                 var url = this._parseUrl(this.url);

--- a/test/d2l-ajax/d2l-ajax.html
+++ b/test/d2l-ajax/d2l-ajax.html
@@ -40,6 +40,15 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="custom-headers-fixture-relative-url">
+			<template>
+				<d2l-ajax
+					url="/path/to/data"
+					headers='{ "Accept": "application/vnd.siren+json", "X-My-Header": "my value" }'
+					></d2l-ajax>
+			</template>
+		</test-fixture>
+
 		<script src="d2l-ajax.js"></script>
 	</body>
 </html>

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -188,5 +188,23 @@ describe('smoke test', function() {
 
 			component.generateRequest();
 		});
+
+		it('should include specified headers in the request for relative path', function (done) {
+			component = fixture('custom-headers-fixture-relative-url');
+			component.$$('iron-localstorage').reload();
+			component.cachedTokens[defaultScope] = authToken;
+
+			server.respondWith(
+				'GET',
+				component.url,
+				function (req) {
+					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
+					expect(req.requestHeaders['x-my-header']).to.equal('my value');
+					req.respond(200);
+					done();
+				});
+
+			component.generateRequest();
+		});
 	});
 });


### PR DESCRIPTION
Due to a data binding issue, headers were only getting sent for absolute path requests. I've tested end-to-end and this should be all good now.