### PR TITLE
Fix bindings for lastResponse and lastError

### DIFF
--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -79,13 +79,11 @@
                 },
                 lastResponse: {
                     type: Object,
-                    notify: true,
-                    readOnly: true
+                    notify: true
                 },
                 lastError: {
                     type: Object,
-                    notify: true,
-                    readOnly: true
+                    notify: true
                 },
                 scope: {
                     type: String,

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -206,5 +206,43 @@ describe('smoke test', function() {
 
 			component.generateRequest();
 		});
+
+		it('should set lastResponse after successful request', function (done) {
+			component = fixture('relative-path-fixture');
+			component.$$('iron-localstorage').reload();
+
+			server.respondWith(
+				'GET',
+				component.url,
+				function (req) {
+					req.respond(200);
+				});
+
+			component.addEventListener('response', function () {
+				expect(component.lastResponse).to.be.defined;
+				done();
+			});
+
+			component.generateRequest();
+		});
+
+		it('should set lastError after unsuccessful request', function (done) {
+			component = fixture('relative-path-fixture');
+			component.$$('iron-localstorage').reload();
+
+			server.respondWith(
+				'GET',
+				component.url,
+				function (req) {
+					req.respond(404);
+				});
+
+			component.addEventListener('error', function () {
+				expect(component.lastError).to.be.defined;
+				done();
+			});
+
+			component.generateRequest();
+		});
 	});
 });


### PR DESCRIPTION
Properties were set as read only so they weren't getting updated properly when the underlying `iron-ajax` component set a value for them.