### PR TITLE
Use session storage to persist token

### DIFF
--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -223,7 +223,8 @@
                 return Promise
                     .resolve()
                     .then(function () {
-                        var cached = this.cachedTokens[scope];
+                        var cached = JSON.parse(window.sessionStorage.getItem(scope)) || this.cachedTokens[scope];
+
                         if (cached) {
                             if (!this._tokenExpired(cached)) {
                                 return cached.access_token;
@@ -276,6 +277,7 @@
                     .then(authTokenRequest);
             },
             _cacheToken: function (scope, token) {
+                window.sessionStorage.setItem(scope, JSON.stringify(token));
                 this.cachedTokens[scope] = token;
             },
             _tokenExpired: function (token) {

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -144,6 +144,15 @@ describe('smoke test', function() {
 				});
 		});
 
+		it('should use sessionStorage token if it exists', function (done) {
+			window.sessionStorage[defaultScope] = JSON.stringify(authToken);
+			component._getAuthToken()
+				.then(function (token) {
+					expect(token).to.equal(authToken.access_token);
+					done();
+				});
+		});
+
 		it('should use cached auth token if it exists', function (done) {
 			component.cachedTokens[defaultScope] = authToken;
 			component._getAuthToken()


### PR DESCRIPTION
If we've already got a token for a particular scope, then there's no need to re-fetch the token for subsequent requests. This should mean that only one request to /token will get fired, when a page first loads, and subsequent requests will just hit the cache.