### PR TITLE
using prefixed error names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
-node_js:
-- 4
+node_js: stable
 sudo: false
 addons:
   firefox: latest

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ See the iron-ajax [documentation](https://elements.polymer-project.org/elements/
     url="http://service.api.brightspace.com/"
     headers='{ "Accept": "application/vnd.siren+json\" }'
     handle-as="json"
-    on-response="handleResponse"
+    on-iron-ajax-response="handleResponse"
+    on-iron-ajax-error="handleError"
     last-response="{{response}}"
     ></d2l-ajax>
 ```

--- a/d2l-ajax.html
+++ b/d2l-ajax.html
@@ -17,9 +17,9 @@
 			timeout="{{timeout}}"
 			last-error="{{lastError}}"
 			last-response="{{lastResponse}}"
-			on-error="onError"
-			on-request="onRequest"
-			on-response="onResponse"></iron-ajax>
+			on-iron-ajax-error="onError"
+			on-iron-ajax-request="onRequest"
+			on-iron-ajax-response="onResponse"></iron-ajax>
 
 		<iron-localstorage
 			name="XSRF.Token"
@@ -176,13 +176,13 @@
 				if (e && e.detail) {
 					data = e.detail;
 				}
-				this.fire('error', data);
+				this.fire('iron-ajax-error', data);
 			},
 			onRequest: function(e) {
-				this.fire('request', e.detail);
+				this.fire('iron-ajax-request', e.detail);
 			},
 			onResponse: function(e) {
-				this.fire('response', e.detail);
+				this.fire('iron-ajax-response', e.detail);
 			},
 			_requestOptionsChanged: function() {
 				if (this.url == null) {

--- a/test/d2l-ajax/d2l-ajax.js
+++ b/test/d2l-ajax/d2l-ajax.js
@@ -92,7 +92,7 @@ describe('smoke test', function() {
 					req.respond(404);
 				});
 
-			component.addEventListener('error', function (e) {
+			component.addEventListener('iron-ajax-error', function (e) {
 				expect(e).to.not.be.undefined;
 				expect(component.lastError).to.not.be.undefined;
 				done();
@@ -173,7 +173,7 @@ describe('smoke test', function() {
 					req.respond(404);
 				});
 
-			component.addEventListener('error', function (e) {
+			component.addEventListener('iron-ajax-error', function (e) {
 				expect(e).to.not.be.undefined;
 				expect(component.lastError).to.not.be.undefined;
 				done();
@@ -292,7 +292,7 @@ describe('smoke test', function() {
 					req.respond(200);
 				});
 
-			component.addEventListener('response', function () {
+			component.addEventListener('iron-ajax-response', function () {
 				expect(component.lastResponse).to.not.be.undefined;
 				done();
 			});
@@ -311,7 +311,7 @@ describe('smoke test', function() {
 					req.respond(404);
 				});
 
-			component.addEventListener('error', function () {
+			component.addEventListener('iron-ajax-error', function () {
 				expect(component.lastError).to.not.be.undefined;
 				done();
 			});


### PR DESCRIPTION
@ryantmer FYI, this will be a major version bump

These changes were necessary due to [this change in iron-ajax](https://github.com/PolymerElements/iron-ajax/pull/194). Essentially, when certain events are fired like "error", some browsers (like Firefox and IE) treat them differently (they're reserved event names) and don't let them bubble through the shadow DOM. As a result, they introduced event names prefixed with "iron-ajax-*".

I was also getting errors in my web-component-tester tests `on-error` in those same browsers, and this fixes them.

@dbatiste: this confirms for me that going with prefixed event names for the component is the way to go, even if it makes the markup a little uglier.